### PR TITLE
[Ralph] #76 docs: 添加 live validation marker 到 live-chain-validation.md

### DIFF
--- a/.sleep_coding/issue-76.md
+++ b/.sleep_coding/issue-76.md
@@ -1,0 +1,36 @@
+# Ralph Task
+
+- task_id: efac3586-8e69-488e-adca-78d64af5e752
+- issue_number: 76
+- branch: codex/issue-76-sleep-coding
+
+## Summary
+Implement Issue #76: docs: 添加 live validation marker 到 live-chain-validation.md
+
+## Scope
+- Read the issue context and confirm the affected modules.
+- Implement the minimum code path required for the issue.
+- Prepare a reviewable branch and PR summary.
+
+## Validation
+- Run python scripts/run_sleep_coding_validation.py
+- Record the command, exit code, and captured output in task state.
+
+## Risks
+- Issue details may be incomplete, so the generated plan may need human correction.
+- Current issue context: ## 背景
+
+需要添加一个最小化的真实链路验证记录，以满足内部验证流程要求。
+
+## 修改范围
+
+- 文件：`docs/internal/live-chain-validation.md`
+- 操作：仅追加一行 live validation marker
+- 约束：保持改动最小，避免引入额外重构
+
+## 实现要求
+
+
+
+## Working Branch
+- codex/issue-76-sleep-coding

--- a/docs/internal/live-chain-validation.md
+++ b/docs/internal/live-chain-validation.md
@@ -1,0 +1,3 @@
+# Live Chain Validation
+
+- live validation marker: 2026-03-20 <!-- ralph-e2e-issue-76 -->


### PR DESCRIPTION
## Summary
Implement Issue #76: docs: 添加 live validation marker 到 live-chain-validation.md

## Validation
- python scripts/run_sleep_coding_validation.py
- status: passed
- exit_code: 0
