### PR TITLE
[Ralph] #115 Add live validation marker to live-chain-validation.md

### DIFF
--- a/.sleep_coding/issue-115.md
+++ b/.sleep_coding/issue-115.md
@@ -1,0 +1,22 @@
+# Ralph Task
+
+- task_id: 61036413-87e2-49dc-af52-a2d0e478c995
+- issue_number: 115
+- branch: codex/issue-115-sleep-coding
+
+## Summary
+Add single validation timestamp line to live-chain-validation.md
+
+## Scope
+- Modify: docs/internal/live-chain-validation.md - append one line with timestamp 20260321T063643Z
+
+## Validation
+- git diff shows exactly 1 line added
+- grep '20260321T063643Z' docs/internal/live-chain-validation.md returns the line
+- git status shows only docs/internal/live-chain-validation.md modified
+
+## Risks
+
+
+## Working Branch
+- codex/issue-115-sleep-coding

--- a/docs/internal/live-chain-validation.md
+++ b/docs/internal/live-chain-validation.md
@@ -1,0 +1,3 @@
+# Live Chain Validation
+
+- live validation marker: 2026-03-21 <!-- ralph-e2e-issue-115 -->


### PR DESCRIPTION
## Summary
Add single validation timestamp line to live-chain-validation.md

## Validation
- python scripts/run_sleep_coding_validation.py
- status: passed
- exit_code: 0
