### PR TITLE
[Ralph] #133 Add live validation marker to live-chain-validation.md

### DIFF
--- a/.sleep_coding/issue-133.md
+++ b/.sleep_coding/issue-133.md
@@ -1,0 +1,29 @@
+# Ralph Task
+
+- task_id: 8659ced1-8bb9-4355-9371-bf297a5a403a
+- issue_number: 133
+- branch: codex/issue-133-sleep-coding
+
+## Summary
+Implement Issue #133: Add live validation marker to live-chain-validation.md
+
+## Scope
+- Read the issue context and confirm the affected modules.
+- Implement the minimum code path required for the issue.
+- Prepare a reviewable branch and PR summary.
+
+## Validation
+- Run python scripts/run_sleep_coding_validation.py
+- Record the command, exit code, and captured output in task state.
+
+## Risks
+- Issue details may be incomplete, so the generated plan may need human correction.
+- Current issue context: ## Goal
+在 docs/internal/live-chain-validation.md 追加一行 live validation marker，验证最小改动链路。
+
+## Requirements
+1. 只对 `docs/internal/live-chain-validation.md` 追加一行
+2. m
+
+## Working Branch
+- codex/issue-133-sleep-coding

--- a/docs/internal/live-chain-validation.md
+++ b/docs/internal/live-chain-validation.md
@@ -1,0 +1,3 @@
+# Live Chain Validation
+
+- live validation marker: 2026-03-22 <!-- ralph-e2e-issue-133 -->


### PR DESCRIPTION
## Summary
Implement Issue #133: Add live validation marker to live-chain-validation.md

## Validation
- python scripts/run_sleep_coding_validation.py
- status: passed
- exit_code: 0
