### PR TITLE
[Ralph] #157 添加 live validation marker 到 live-chain-validation.md

### DIFF
--- a/.sleep_coding/issue-157.md
+++ b/.sleep_coding/issue-157.md
@@ -1,0 +1,31 @@
+# Ralph Task
+
+- task_id: 1f851716-3dd5-4145-81d0-2294423faf61
+- issue_number: 157
+- branch: codex/issue-157-sleep-coding
+
+## Summary
+Implement Issue #157: 添加 live validation marker 到 live-chain-validation.md
+
+## Scope
+- Read the issue context and confirm the affected modules.
+- Implement the minimum code path required for the issue.
+- Prepare a reviewable branch and PR summary.
+
+## Validation
+- Run python scripts/run_sleep_coding_validation.py
+- Record the command, exit code, and captured output in task state.
+
+## Risks
+- Issue details may be incomplete, so the generated plan may need human correction.
+- Current issue context: ## 任务目标
+
+在 `docs/internal/live-chain-validation.md` 文件末尾追加一行 live validation marker。
+
+## 具体要求
+
+1. **只修改一个文件**: `docs/internal/live-chain-validation.md`
+2. **只追加
+
+## Working Branch
+- codex/issue-157-sleep-coding

--- a/docs/internal/live-chain-validation.md
+++ b/docs/internal/live-chain-validation.md
@@ -1,0 +1,3 @@
+# Live Chain Validation
+
+- live validation marker: 2026-03-22 <!-- ralph-e2e-issue-157 -->


### PR DESCRIPTION
## Summary
Implement Issue #157: 添加 live validation marker 到 live-chain-validation.md

## Validation
- python scripts/run_sleep_coding_validation.py
- status: passed
- exit_code: 0
