### PR TITLE
[Ralph] #171 [最小验证] 为 live-chain-validation.md 添加 live validation marker

### DIFF
--- a/.sleep_coding/issue-171.md
+++ b/.sleep_coding/issue-171.md
@@ -1,0 +1,31 @@
+# Ralph Task
+
+- task_id: 23989420-3345-4cc3-97a4-e7fae741545e
+- issue_number: 171
+- branch: codex/issue-171-sleep-coding
+
+## Summary
+Implement Issue #171: [最小验证] 为 live-chain-validation.md 添加 live validation marker
+
+## Scope
+- Read the issue context and confirm the affected modules.
+- Implement the minimum code path required for the issue.
+- Prepare a reviewable branch and PR summary.
+
+## Validation
+- Run python scripts/run_sleep_coding_validation.py
+- Record the command, exit code, and captured output in task state.
+
+## Risks
+- Issue details may be incomplete, so the generated plan may need human correction.
+- Current issue context: ## 目标
+
+为 `docs/internal/live-chain-validation.md` 追加一行 live validation marker，验证真实链路是否正常工作。
+
+## 具体要求
+
+1. **目标文件**: `docs/internal/live-chain-validation.md`
+2. *
+
+## Working Branch
+- codex/issue-171-sleep-coding

--- a/docs/internal/live-chain-validation.md
+++ b/docs/internal/live-chain-validation.md
@@ -1,0 +1,3 @@
+# Live Chain Validation
+
+- live validation marker: 2026-03-23 <!-- ralph-e2e-issue-171 -->


### PR DESCRIPTION
## Summary
Implement Issue #171: [最小验证] 为 live-chain-validation.md 添加 live validation marker

## Validation
- python scripts/run_sleep_coding_validation.py
- status: passed
- exit_code: 0
