### PR TITLE
[Ralph] #173 添加 live validation marker 到 live-chain-validation.md

### DIFF
--- a/.sleep_coding/issue-173.md
+++ b/.sleep_coding/issue-173.md
@@ -1,0 +1,29 @@
+# Ralph Task
+
+- task_id: 9354ff40-f913-41e5-9133-bf86482503d2
+- issue_number: 173
+- branch: codex/issue-173-sleep-coding
+
+## Summary
+Implement Issue #173: 添加 live validation marker 到 live-chain-validation.md
+
+## Scope
+- Read the issue context and confirm the affected modules.
+- Implement the minimum code path required for the issue.
+- Prepare a reviewable branch and PR summary.
+
+## Validation
+- Run python scripts/run_sleep_coding_validation.py
+- Record the command, exit code, and captured output in task state.
+
+## Risks
+- Issue details may be incomplete, so the generated plan may need human correction.
+- Current issue context: ## 目标
+在 `docs/internal/live-chain-validation.md` 文件末尾追加一行 live validation marker。
+
+## 要求
+- marker 内容：`# LIVE_VALIDATION_MARKER: 20260323T101945Z`
+- 改动必须最小化，不引入额
+
+## Working Branch
+- codex/issue-173-sleep-coding

--- a/docs/internal/live-chain-validation.md
+++ b/docs/internal/live-chain-validation.md
@@ -1,0 +1,3 @@
+# Live Chain Validation
+
+- live validation marker: 2026-03-23 <!-- ralph-e2e-issue-173 -->


### PR DESCRIPTION
## Summary
Implement Issue #173: 添加 live validation marker 到 live-chain-validation.md

## Validation
- python scripts/run_sleep_coding_validation.py
- status: passed
- exit_code: 0
