### PR TITLE
[Ralph] #178 Add live validation marker to live-chain-validation.md

### DIFF
--- a/.sleep_coding/issue-178.md
+++ b/.sleep_coding/issue-178.md
@@ -1,0 +1,14 @@
+# Ralph Task
+
+- task_id: e2781b36-3850-4831-87c5-f890a71a0587
+- issue_number: 178
+- branch: codex/issue-178-sleep-coding
+
+## Summary
+Task 178: Add live validation marker to live-chain-validation.md
+
+**Implementation**: Appended single line with timestamp `20260323T152423Z` to the target file.
+
+**Validation**: Ran `grep "20260323T152423Z" docs/internal/live-chain-validation.md` - marker found at file end.
+
+**Risks**: Minimal - append-only operation with no content modification.

--- a/docs/internal/live-chain-validation.md
+++ b/docs/internal/live-chain-validation.md
@@ -1,0 +1,1 @@
+Live validation timestamp: 20260323T152423Z


### PR DESCRIPTION
## Summary
Implement Issue #178: Add live validation marker to live-chain-validation.md

## Validation
- python scripts/run_sleep_coding_validation.py
- status: passed
- exit_code: 0
