### PR TITLE
[Ralph] #194 [最小改动] 为 live-chain-validation.md 添加 live validation marker

### DIFF
--- a/.sleep_coding/issue-194.md
+++ b/.sleep_coding/issue-194.md
@@ -1,0 +1,24 @@
+# Ralph Task
+
+- task_id: fc2717ab-290d-414d-a8bd-4a964f86bfeb
+- issue_number: 194
+- branch: codex/issue-194-sleep-coding
+
+## Summary
+
+Task #194: Add live validation marker to live-chain-validation.md
+
+### Implementation
+
+Read `docs/internal/live-chain-validation.md`, then append a single line with live validation marker containing timestamp `20260323T162908Z`.
+
+### Validation
+
+1. Verify file exists
+2. Confirm diff is exactly 1 line
+3. Confirm marker contains timestamp
+
+### Risks
+
+- File must exist (assumed per issue)
+- Minimal change, low risk

--- a/docs/internal/live-chain-validation.md
+++ b/docs/internal/live-chain-validation.md
@@ -1,0 +1,1 @@
+<!-- live-validation-marker: 20260323T162908Z -->


### PR DESCRIPTION
## Summary
Implement Issue #194: [最小改动] 为 live-chain-validation.md 添加 live validation marker

## Validation
- python scripts/run_sleep_coding_validation.py
- status: passed
- exit_code: 0
